### PR TITLE
Re-order dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
     },
     "dependencies": {
-        "@types/node": "^11.13.0",
-        "@types/react": "^16.0.0",
         "create-react-context": "^0.3.0"
     },
     "devDependencies": {
@@ -61,7 +59,9 @@
         "@types/expect-puppeteer": "^3.3.1",
         "@types/jest": "^24.0.11",
         "@types/jest-environment-puppeteer": "^4.0.0",
+        "@types/node": "^11.13.0",
         "@types/puppeteer": "^1.12.3",
+        "@types/react": "^16.0.0",
         "core-js": "3",
         "cross-env": "^5.2.0",
         "dotenv": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rebilly/framepay-react",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "A React wrapper for Rebilly's FramePay offering out-of-the-box support for Redux and other common React features",
     "main": "build/index.js",
     "author": "Rebilly",


### PR DESCRIPTION
Move @types to devDependencies, since they are not required for our prod build