### PR TITLE
Fix: Upgrade parcel dependency to fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "jsdom": "^14.0.0",
         "jsdom-global": "^3.0.2",
         "npm-run-all": "^4.1.5",
-        "parcel": "^1.12.3",
+        "parcel-bundler": "^1.12.5",
         "portfinder": "^1.0.20",
         "prettier": "^1.15.2",
         "puppeteer": "^1.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,7 +5819,7 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-forge@^0.10.0, node-forge@^0.7.1:
+node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
@@ -6209,10 +6209,10 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-parcel@^1.12.3:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/parcel/-/parcel-1.12.4.tgz#c8136085179c6382e632ca98126093e110be2ac5"
-  integrity sha512-qfc74e2/R4pCoU6L/ZZnK9k3iDS6ir4uHea0e9th9w52eehcAGf2ido/iABq9PBXdsIOe4NSY3oUm7Khe7+S3w==
+parcel-bundler@^1.12.5:
+  version "1.12.5"
+  resolved "https://registry.yarnpkg.com/parcel-bundler/-/parcel-bundler-1.12.5.tgz#91f7de1c1fbfe5111616d3211c749c85c4d8acf0"
+  integrity sha512-hpku8mW67U6PXQIenW6NBbphBOMb8XzW6B9r093DUhYj5GN2FUB/CXCiz5hKoPYUsusZ35BpProH8AUF9bh5IQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.4.4"
@@ -6257,7 +6257,7 @@ parcel@^1.12.3:
     json5 "^1.0.1"
     micromatch "^3.0.4"
     mkdirp "^0.5.1"
-    node-forge "^0.7.1"
+    node-forge "^0.10.0"
     node-libs-browser "^2.0.0"
     opn "^5.1.0"
     postcss "^7.0.11"


### PR DESCRIPTION
### Currently

Some changes were published in `@babel/preset-env` that cause our current version of parcel to fail during build.

For details see: https://github.com/parcel-bundler/parcel/issues/5943

To reproduce:
- Check out `main`
- Try to run `yarn serve:e2e`
- Notice the build issue: 
![image](https://user-images.githubusercontent.com/492636/151943275-b7235dee-c0e2-4fb7-a519-7844f00bc9a4.png)

### Description

This PR fixes the issue by upgrading our parcel version to `1.12.5` which contains a fix for this, see: 
See: https://github.com/parcel-bundler/parcel/issues/5943#issuecomment-799899064

We have to change the parcel npm package back to `parcel-bundler` to get this version, `parcel` has two npm packages, the old `parcel-bundler` and the newer `parcel` package. Unfortunately `1.12.5` is not published on the newer package name, only on `parcel-bundler`.
