### PR TITLE
fix: Unregister token-ready handlers when unmounting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rebilly/framepay-react",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "A React wrapper for Rebilly's FramePay offering out-of-the-box support for Redux and other common React features",
     "main": "build/index.js",
     "author": "Rebilly",

--- a/src/lib/components/elements/applepay-element.tsx
+++ b/src/lib/components/elements/applepay-element.tsx
@@ -33,7 +33,7 @@ export default class ApplePayElement extends BaseElement<
         const element = makeElement();
 
         try {
-            Rebilly.on('token-ready', (token: string) => {
+            this.addEventHandler('token-ready', (token: string) => {
                 if (onTokenReady) {
                     onTokenReady(token);
                 }

--- a/src/lib/components/elements/base-element.tsx
+++ b/src/lib/components/elements/base-element.tsx
@@ -13,9 +13,20 @@ export default class BaseElement<
     /* tslint:disable:readonly-keyword */
     protected elementNode: HTMLDivElement | null = null;
 
+    private registeredEventHandlers: ReadonlyArray<{
+        event: initRebillyEvents;
+        delegate: RebillyEventDelegate;
+    }> = [];
+
     /* tslint:enable:readonly-keyword */
 
     componentWillUnmount() {
+        // Remove all the registered event handlers
+        const { Rebilly } = this.props;
+        this.registeredEventHandlers.forEach(({ event, delegate }) => {
+            Rebilly.off(event, delegate);
+        });
+
         if (this.state.mounted && !this.state.element) {
             // tslint:disable-next-line:no-console
             console.log(
@@ -96,5 +107,21 @@ export default class BaseElement<
         return (
             <div id={this.props.id} ref={node => (this.elementNode = node)} />
         );
+    }
+
+    /**
+     * Registers a framepay event handler using Rebilly.on(), which will automatically be
+     * disposed of when the element is umounted.
+     */
+    addEventHandler(event: initRebillyEvents, delegate: RebillyEventDelegate) {
+        const { Rebilly } = this.props;
+        Rebilly.on(event, delegate);
+        this.registeredEventHandlers = [
+            ...this.registeredEventHandlers,
+            {
+                delegate,
+                event
+            }
+        ];
     }
 }

--- a/src/lib/components/elements/googlepay-element.tsx
+++ b/src/lib/components/elements/googlepay-element.tsx
@@ -33,7 +33,7 @@ export default class GooglePayElement extends BaseElement<
         const element = makeElement();
 
         try {
-            Rebilly.on('token-ready', (token: string) => {
+            this.addEventHandler('token-ready', (token: string) => {
                 if (onTokenReady) {
                     onTokenReady(token);
                 }

--- a/src/lib/components/elements/paypal-element.tsx
+++ b/src/lib/components/elements/paypal-element.tsx
@@ -33,7 +33,7 @@ export default class PaypalElement extends BaseElement<
         const element = makeElement();
 
         try {
-            Rebilly.on('token-ready', (token: string) => {
+            this.addEventHandler('token-ready', (token: string) => {
                 if (onTokenReady) {
                     onTokenReady(token);
                 }

--- a/test/e2e/fixtures/multiple-methods.js
+++ b/test/e2e/fixtures/multiple-methods.js
@@ -6,7 +6,14 @@ import { deepMerge, prettyDebugRender, ReactVersion } from './util';
 import './style.css';
 
 const params = {
-    publishableKey: 'pk_sandbox_c6cqKLddciVikuBOjhcng-rLccTz70NT4W_qZ_h'
+    publishableKey: 'pk_sandbox_S95ATjj4hXZs-T9QpZq1ENl2tDSrUkCGv98utc9',
+    organizationId: '5977150c-1c97-4dd4-9860-6bb2bab070b4',
+    websiteId: 'demo.com',
+    transactionData: {
+        amount: 10,
+        currency: 'USD',
+        label: 'Purchase label 1',
+    },
 };
 
 const defaultEvents = () => ({
@@ -15,6 +22,9 @@ const defaultEvents = () => ({
         onChange: false,
         onFocus: false,
         onBlur: false
+    },
+    googlepay: {
+        onTokenReady: false,
     },
     bankAccountType: {
         onReady: false,
@@ -50,7 +60,8 @@ class PaymentFormComponent extends Component {
                 // {element: method}
                 card: 'payment-card',
                 bank: 'ach',
-                iban: 'ach'
+                iban: 'ach',
+                googlepay: 'googlepay'
             },
             paymentElement: 'card',
             events: {
@@ -200,6 +211,17 @@ class PaymentFormComponent extends Component {
                                                 this.deepUpdateState({
                                                     events: {
                                                         card: { onBlur: true }
+                                                    }
+                                                })
+                                            }
+                                        />
+                                    )}
+                                    {this.state.paymentElement === 'googlepay' && (
+                                        <this.props.GooglePayElement
+                                            onTokenReady={() =>
+                                                this.deepUpdateState({
+                                                    events: {
+                                                        googlepay: { onTokenReady: true }
                                                     }
                                                 })
                                             }

--- a/test/unit/specs/lib/components/elements/base-element.spec.tsx
+++ b/test/unit/specs/lib/components/elements/base-element.spec.tsx
@@ -1,0 +1,50 @@
+import { Substitute } from '@fluffy-spoon/substitute';
+import { mount } from 'enzyme';
+import * as React from 'react';
+import BaseElement from '../../../../../../src/lib/components/elements/base-element';
+
+describe('lib/components/elements/BaseElement', () => {
+    it('should unregister any event handlers on destroy', done => {
+        const element = Substitute.for<PaymentElement>();
+        const eventHandler = (token: string) => {};
+
+        const props = {
+            Rebilly: {
+                ready: true,
+                on: jest.fn(),
+                off: jest.fn()
+            }
+        };
+
+        class TmpComponent extends BaseElement<
+            PaymentComponentProps,
+            PaymentComponentState
+        > {
+            setupElement() {
+                this.addEventHandler('token-ready', eventHandler);
+                this.setState({ element });
+            }
+        }
+
+        const wrapper = mount(
+            <TmpComponent {...props} Rebilly={props.Rebilly} />
+        );
+        process.nextTick(() => {
+            wrapper.unmount();
+
+            expect(props.Rebilly.on).toHaveBeenCalledTimes(1);
+            expect(props.Rebilly.on).toHaveBeenLastCalledWith(
+                'token-ready',
+                eventHandler
+            );
+
+            expect(props.Rebilly.off).toHaveBeenCalledTimes(1);
+            expect(props.Rebilly.off).toHaveBeenLastCalledWith(
+                'token-ready',
+                eventHandler
+            );
+
+            done();
+        });
+    });
+});

--- a/types/rebilly/api.d.ts
+++ b/types/rebilly/api.d.ts
@@ -28,6 +28,8 @@ interface TokenExtraData {
     readonly leadSource?: object;
 }
 
+type RebillyEventDelegate =  (error: string) => void;
+
 /**
  * The FramePay api interface (external api)
  */
@@ -46,6 +48,11 @@ interface RebillyApi {
 
     readonly on: (
         event: initRebillyEvents,
-        callback: (error: string) => void
+        callback: RebillyEventDelegate
+    ) => void;
+
+    readonly off: (
+        event: initRebillyEvents,
+        callback: RebillyEventDelegate
     ) => void;
 }


### PR DESCRIPTION
This PR fixes an issue where `token-ready` handlers were not unregistered when a component is unmounted, causing re-execution the next time the component is mounted and the event is fired.

The PR:
- Adds a new function to base element that we should use when adding global event handlers, so that they can be removed when the components are umounted
- Updates the components that use token-ready to use the new function (Google Pay, Paypal, Apple Pay)
- Updates the multiple-method example page to include google pay as a method

How to test:
- checkout the branch
- Edit the `multiple-methods.js` file on line 221 to console log on token ready, like:
   - `onTokenReady={() => console.log("Token ready handler")}`
- Run yarn serve:e2e
- Visit http://localhost:8000/ and test the multiple methods page
- Load google pay, load card, load google pay, make a google pay payment
- Notice your handler is only run once

Before:
<img width="516" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/492636/209913159-63baec33-bd6b-453c-8cdd-880165123cb5.png">

After:
<img width="494" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/492636/209913171-3fff3d1b-3233-4afb-97df-360c6123c5e7.png">
