### PR TITLE
test: Update version checking e2e tests

### DIFF
--- a/test/e2e/specs/bank-separate.spec.ts
+++ b/test/e2e/specs/bank-separate.spec.ts
@@ -15,13 +15,10 @@ describe('bank-separate', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 

--- a/test/e2e/specs/card-separate-brands.spec.ts
+++ b/test/e2e/specs/card-separate-brands.spec.ts
@@ -15,13 +15,10 @@ describe('card-separate-brands', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 

--- a/test/e2e/specs/card-separate.spec.ts
+++ b/test/e2e/specs/card-separate.spec.ts
@@ -15,13 +15,10 @@ describe('card-separate', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 

--- a/test/e2e/specs/checkout-combined.spec.ts
+++ b/test/e2e/specs/checkout-combined.spec.ts
@@ -15,13 +15,10 @@ describe('checkout-combined', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 

--- a/test/e2e/specs/iban.spec.ts
+++ b/test/e2e/specs/iban.spec.ts
@@ -11,13 +11,10 @@ describe('iban', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 

--- a/test/e2e/specs/multiple-methods.spec.ts
+++ b/test/e2e/specs/multiple-methods.spec.ts
@@ -13,13 +13,10 @@ describe('multiple-methods', () => {
     it('should render with correct react version', async () => {
         const version = await page.$eval('#react-version', el => el.innerHTML);
 
-        const pkg = require('../../../package.json');
-
-        if (process.env.REACT_VERSION === 'latest') {
-            expect(version).toEqual(pkg.devDependencies.react.slice(1));
-        } else {
-            expect(version).toEqual(process.env.REACT_VERSION);
-        }
+        expect(
+            process.env.REACT_VERSION &&
+                version.startsWith(process.env.REACT_VERSION)
+        ).toBe(true);
         expect(version.length >= 6).toEqual(true);
     });
 


### PR DESCRIPTION
This PR fixes some existing e2e tests.

As part of https://github.com/Rebilly/framepay-react/pull/65 the concept of `react-latest` was removed, and versions `16` and `17`, `18` were made not to use a specific version number but only the major number, so that if an update to those versions comes out, we can update the lib files without needing to update all the commands and assertions.

It broke some e2e tests which were passing, so this PR fixes those tests.

How to test:
- Checkout this branch
- Run `yarn test:e2e:react-17` for example

Before:
<img width="328" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/492636/210917340-d2f91327-2577-44f1-98d1-a0fd87b89cf1.png">

After:
<img width="399" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/492636/210917346-11aaa1e0-0b32-43da-ae7d-722a56d66b54.png">
