### PR TITLE
Bump version to 1.6.0 following recent changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rebilly/framepay-react",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "description": "A React wrapper for Rebilly's FramePay offering out-of-the-box support for Redux and other common React features",
     "main": "build/index.js",
     "author": "Rebilly",


### PR DESCRIPTION
Following recent PRs:
- [Add cypress E2E test setup and convert 1 spec](https://github.com/Rebilly/framepay-react/pull/74)
- [Puppeteer to Cypress E2E tests migration](https://github.com/Rebilly/framepay-react/pull/75)
- [Convert multiple-methods spec to cypress](https://github.com/Rebilly/framepay-react/pull/76)
- [Remove puppeteer E2E test setup and bump jest](https://github.com/Rebilly/framepay-react/pull/77)
- [Consolidating Cypress tests into the e2e folder / Upgrade GHA to Node v18 / Minor improvements](https://github.com/Rebilly/framepay-react/pull/78)
- [dev: Auto-generate SSL certificates and run with https](https://github.com/Rebilly/framepay-react/pull/79)

We opted in to change the version to `1.6.0` since few libraries got updated and node version was bumped to LTS (v18)
